### PR TITLE
Setup minimal GraphEngine API with OpenAPI and source-generated JSON

### DIFF
--- a/GraphEngine.Api/ApiJsonSerializerContext.cs
+++ b/GraphEngine.Api/ApiJsonSerializerContext.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace GraphEngine.Api;
+
+[JsonSerializable(typeof(ExecuteGraphRequest))]
+[JsonSerializable(typeof(ExecuteGraphResponse))]
+[JsonSerializable(typeof(SerializeGraphRequest))]
+[JsonSerializable(typeof(SerializeGraphResponse))]
+internal partial class ApiJsonSerializerContext : JsonSerializerContext;

--- a/GraphEngine.Api/GraphDtos.cs
+++ b/GraphEngine.Api/GraphDtos.cs
@@ -1,0 +1,7 @@
+namespace GraphEngine.Api;
+
+public record ExecuteGraphRequest(string Graph);
+public record ExecuteGraphResponse(string Result);
+
+public record SerializeGraphRequest(string Graph);
+public record SerializeGraphResponse(string Serialized);

--- a/GraphEngine.Api/Program.cs
+++ b/GraphEngine.Api/Program.cs
@@ -1,6 +1,29 @@
-var builder = WebApplication.CreateBuilder(args);
+using GraphEngine.Api;
+
+var builder = WebApplication.CreateSlimBuilder(args);
+
+builder.Services.AddOpenApi();
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.TypeInfoResolverChain.Insert(0, ApiJsonSerializerContext.Default);
+});
+
 var app = builder.Build();
 
-app.MapGet("/", () => "Hello World!");
+app.MapOpenApi();
+
+app.MapPost("/graph/execute", (ExecuteGraphRequest request) =>
+{
+    var response = new ExecuteGraphResponse($"Executed: {request.Graph}");
+    return Results.Ok(response);
+});
+
+app.MapPost("/graph/serialize", (SerializeGraphRequest request) =>
+{
+    var response = new SerializeGraphResponse($"Serialized: {request.Graph}");
+    return Results.Ok(response);
+});
+
+app.MapGet("/graph/status", () => Results.Ok("Graph engine is ready"));
 
 app.Run();


### PR DESCRIPTION
## Summary
- use `WebApplication.CreateSlimBuilder` for a minimal API
- expose graph endpoints and OpenAPI documentation
- configure System.Text.Json source generation for DTOs

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689e89ef78448332a7f3cd772f3da517